### PR TITLE
issue #29 fix - provide auth scheme when using AddOpenIdConnect

### DIFF
--- a/Samples/silent-auth/Startup.cs
+++ b/Samples/silent-auth/Startup.cs
@@ -32,7 +32,7 @@ namespace SampleMvcApp
                 options.DefaultChallengeScheme = OpenIdConnectDefaults.AuthenticationScheme;
             })
             .AddCookie()
-            .AddOpenIdConnect("Auth0", options => {
+            .AddOpenIdConnect(OpenIdConnectDefaults.AuthenticationScheme, "Auth0", options => {
                 // Set the authority to your Auth0 domain
                 options.Authority = $"https://{Configuration["Auth0:Domain"]}";
 


### PR DESCRIPTION
the AddOpenIdConnect auth scheme parameter shoud be the same as options.DefaultChallengeScheme used for AddAuthentication