### PR TITLE
[SDK-1957] Fix Samples to work on Http with SameSite None

### DIFF
--- a/Quickstart/00-Starter-Seed/Properties/launchSettings.json
+++ b/Quickstart/00-Starter-Seed/Properties/launchSettings.json
@@ -11,6 +11,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
+      "launchUrl": "http://localhost:3000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/Quickstart/00-Starter-Seed/Startup.cs
+++ b/Quickstart/00-Starter-Seed/Startup.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using SampleMvcApp.Support;
 
 namespace SampleMvcApp
 {
@@ -19,12 +20,7 @@ namespace SampleMvcApp
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.Configure<CookiePolicyOptions>(options =>
-            {
-                // This lambda determines whether user consent for non-essential cookies is needed for a given request.
-                options.CheckConsentNeeded = context => true;
-                options.MinimumSameSitePolicy = SameSiteMode.None;
-            });
+            services.ConfigureSameSiteNoneCookies();
 
             services.AddControllersWithViews();
         }

--- a/Quickstart/00-Starter-Seed/Support/SameSiteServiceCollectionExtensions.cs
+++ b/Quickstart/00-Starter-Seed/Support/SameSiteServiceCollectionExtensions.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace SampleMvcApp.Support
+{
+    public static class SameSiteServiceCollectionExtensions
+    {
+        public static IServiceCollection ConfigureSameSiteNoneCookies(this IServiceCollection services)
+        {
+            services.Configure<CookiePolicyOptions>(options =>
+            {
+                options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
+                options.OnAppendCookie = cookieContext => CheckSameSite(cookieContext.CookieOptions);
+                options.OnDeleteCookie = cookieContext => CheckSameSite(cookieContext.CookieOptions);
+            });
+
+            return services;
+        }
+
+        private static void CheckSameSite(CookieOptions options)
+        {
+            if (options.SameSite == SameSiteMode.None && options.Secure == false)
+            {
+                options.SameSite = SameSiteMode.Unspecified;
+            }
+        }
+    }
+}

--- a/Quickstart/01-Login/Properties/launchSettings.json
+++ b/Quickstart/01-Login/Properties/launchSettings.json
@@ -11,6 +11,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
+      "launchUrl": "http://localhost:3000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/Quickstart/01-Login/Startup.cs
+++ b/Quickstart/01-Login/Startup.cs
@@ -8,29 +8,24 @@ using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
+using SampleMvcApp.Support;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
 namespace SampleMvcApp
 {
     public class Startup
     {
-        public Startup(IConfiguration configuration, IWebHostEnvironment hostingEnvironment)
+        public Startup(IConfiguration configuration)
         {
             Configuration = configuration;
-            HostingEnvironment = hostingEnvironment;
         }
 
         public IConfiguration Configuration { get; }
-        public IWebHostEnvironment HostingEnvironment { get; }
 
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.Configure<CookiePolicyOptions>(options =>
-            {
-                // This lambda determines whether user consent for non-essential cookies is needed for a given request.
-                options.CheckConsentNeeded = context => HostingEnvironment.IsProduction();
-                options.MinimumSameSitePolicy = SameSiteMode.None;
-            });
+            services.ConfigureSameSiteNoneCookies();
 
             // Add authentication services
             services.AddAuthentication(options => {
@@ -48,7 +43,7 @@ namespace SampleMvcApp
                 options.ClientSecret = Configuration["Auth0:ClientSecret"];
 
                 // Set response type to code
-                options.ResponseType = "code";
+                options.ResponseType = OpenIdConnectResponseType.Code;
 
                 // Configure the scope
                 options.Scope.Clear();

--- a/Quickstart/01-Login/Support/SameSiteServiceCollectionExtensions.cs
+++ b/Quickstart/01-Login/Support/SameSiteServiceCollectionExtensions.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace SampleMvcApp.Support
+{
+    public static class SameSiteServiceCollectionExtensions
+    {
+        public static IServiceCollection ConfigureSameSiteNoneCookies(this IServiceCollection services)
+        {
+            services.Configure<CookiePolicyOptions>(options =>
+            {
+                options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
+                options.OnAppendCookie = cookieContext => CheckSameSite(cookieContext.CookieOptions);
+                options.OnDeleteCookie = cookieContext => CheckSameSite(cookieContext.CookieOptions);
+            });
+
+            return services;
+        }
+
+        private static void CheckSameSite(CookieOptions options)
+        {
+            if (options.SameSite == SameSiteMode.None && options.Secure == false)
+            {
+                options.SameSite = SameSiteMode.Unspecified;
+            }
+        }
+    }
+}

--- a/Quickstart/02-User-Profile/Properties/launchSettings.json
+++ b/Quickstart/02-User-Profile/Properties/launchSettings.json
@@ -11,6 +11,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
+      "launchUrl": "http://localhost:3000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/Quickstart/02-User-Profile/Startup.cs
+++ b/Quickstart/02-User-Profile/Startup.cs
@@ -9,29 +9,24 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.IdentityModel.Tokens;
+using SampleMvcApp.Support;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
 namespace SampleMvcApp
 {
     public class Startup
     {
-        public Startup(IConfiguration configuration, IWebHostEnvironment hostingEnvironment)
+        public Startup(IConfiguration configuration)
         {
             Configuration = configuration;
-            HostingEnvironment = hostingEnvironment;
         }
 
         public IConfiguration Configuration { get; }
-        public IWebHostEnvironment HostingEnvironment { get; }
 
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.Configure<CookiePolicyOptions>(options =>
-            {
-                // This lambda determines whether user consent for non-essential cookies is needed for a given request.
-                options.CheckConsentNeeded = context => HostingEnvironment.IsProduction();
-                options.MinimumSameSitePolicy = SameSiteMode.None;
-            });
+            services.ConfigureSameSiteNoneCookies();
 
             // Add authentication services
             services.AddAuthentication(options => {
@@ -49,7 +44,7 @@ namespace SampleMvcApp
                 options.ClientSecret = Configuration["Auth0:ClientSecret"];
 
                 // Set response type to code
-                options.ResponseType = "code";
+                options.ResponseType = OpenIdConnectResponseType.Code;
 
                 // Configure the scope
                 options.Scope.Clear();

--- a/Quickstart/02-User-Profile/Support/SameSiteServiceCollectionExtensions.cs
+++ b/Quickstart/02-User-Profile/Support/SameSiteServiceCollectionExtensions.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace SampleMvcApp.Support
+{
+    public static class SameSiteServiceCollectionExtensions
+    {
+        public static IServiceCollection ConfigureSameSiteNoneCookies(this IServiceCollection services)
+        {
+            services.Configure<CookiePolicyOptions>(options =>
+            {
+                options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
+                options.OnAppendCookie = cookieContext => CheckSameSite(cookieContext.CookieOptions);
+                options.OnDeleteCookie = cookieContext => CheckSameSite(cookieContext.CookieOptions);
+            });
+
+            return services;
+        }
+
+        private static void CheckSameSite(CookieOptions options)
+        {
+            if (options.SameSite == SameSiteMode.None && options.Secure == false)
+            {
+                options.SameSite = SameSiteMode.Unspecified;
+            }
+        }
+    }
+}

--- a/Quickstart/03-Authorization/Properties/launchSettings.json
+++ b/Quickstart/03-Authorization/Properties/launchSettings.json
@@ -11,6 +11,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
+      "launchUrl": "http://localhost:3000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/Quickstart/03-Authorization/Startup.cs
+++ b/Quickstart/03-Authorization/Startup.cs
@@ -9,6 +9,8 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using SampleMvcApp.Support;
 
 namespace SampleMvcApp
 {
@@ -26,12 +28,7 @@ namespace SampleMvcApp
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.Configure<CookiePolicyOptions>(options =>
-            {
-                // This lambda determines whether user consent for non-essential cookies is needed for a given request.
-                options.CheckConsentNeeded = context => HostingEnvironment.IsProduction();
-                options.MinimumSameSitePolicy = SameSiteMode.None;
-            });
+            services.ConfigureSameSiteNoneCookies();
 
             // Add authentication services
             services.AddAuthentication(options => {
@@ -49,7 +46,7 @@ namespace SampleMvcApp
                 options.ClientSecret = Configuration["Auth0:ClientSecret"];
 
                 // Set response type to code
-                options.ResponseType = "code";
+                options.ResponseType = OpenIdConnectResponseType.Code;
 
                 // Configure the scope
                 options.Scope.Clear();

--- a/Quickstart/03-Authorization/Support/SameSiteServiceCollectionExtensions.cs
+++ b/Quickstart/03-Authorization/Support/SameSiteServiceCollectionExtensions.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace SampleMvcApp.Support
+{
+    public static class SameSiteServiceCollectionExtensions
+    {
+        public static IServiceCollection ConfigureSameSiteNoneCookies(this IServiceCollection services)
+        {
+            services.Configure<CookiePolicyOptions>(options =>
+            {
+                options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
+                options.OnAppendCookie = cookieContext => CheckSameSite(cookieContext.CookieOptions);
+                options.OnDeleteCookie = cookieContext => CheckSameSite(cookieContext.CookieOptions);
+            });
+
+            return services;
+        }
+
+        private static void CheckSameSite(CookieOptions options)
+        {
+            if (options.SameSite == SameSiteMode.None && options.Secure == false)
+            {
+                options.SameSite = SameSiteMode.Unspecified;
+            }
+        }
+    }
+}

--- a/Samples/oauth2/Properties/launchSettings.json
+++ b/Samples/oauth2/Properties/launchSettings.json
@@ -11,6 +11,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
+      "launchUrl": "http://localhost:3000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/Samples/oauth2/Startup.cs
+++ b/Samples/oauth2/Startup.cs
@@ -10,6 +10,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
 using Microsoft.Extensions.Hosting;
+using AspNetCoreOAuth2Sample.Support;
 
 namespace AspNetCoreOAuth2Sample
 {
@@ -25,12 +26,7 @@ namespace AspNetCoreOAuth2Sample
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.Configure<CookiePolicyOptions>(options =>
-            {
-                // This lambda determines whether user consent for non-essential cookies is needed for a given request.
-                options.CheckConsentNeeded = context => true;
-                options.MinimumSameSitePolicy = SameSiteMode.None;
-            });
+            services.ConfigureSameSiteNoneCookies();
 
             // Add authentication services
             services.AddAuthentication(options => {

--- a/Samples/oauth2/Support/SameSiteServiceCollectionExtensions.cs
+++ b/Samples/oauth2/Support/SameSiteServiceCollectionExtensions.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace AspNetCoreOAuth2Sample.Support
+{
+    public static class SameSiteServiceCollectionExtensions
+    {
+        public static IServiceCollection ConfigureSameSiteNoneCookies(this IServiceCollection services)
+        {
+            services.Configure<CookiePolicyOptions>(options =>
+            {
+                options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
+                options.OnAppendCookie = cookieContext => CheckSameSite(cookieContext.CookieOptions);
+                options.OnDeleteCookie = cookieContext => CheckSameSite(cookieContext.CookieOptions);
+            });
+
+            return services;
+        }
+
+        private static void CheckSameSite(CookieOptions options)
+        {
+            if (options.SameSite == SameSiteMode.None && options.Secure == false)
+            {
+                options.SameSite = SameSiteMode.Unspecified;
+            }
+        }
+    }
+}

--- a/Samples/oidc-hs256/Startup.cs
+++ b/Samples/oidc-hs256/Startup.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.IdentityModel.Tokens;
+using AspNetCoreOidcSample.Support;
 
 namespace AspNetCoreOidcSample
 {
@@ -25,12 +26,7 @@ namespace AspNetCoreOidcSample
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.Configure<CookiePolicyOptions>(options =>
-            {
-                // This lambda determines whether user consent for non-essential cookies is needed for a given request.
-                options.CheckConsentNeeded = context => true;
-                options.MinimumSameSitePolicy = SameSiteMode.None;
-            });
+            services.ConfigureSameSiteNoneCookies();
 
             // Get the client secret used for signing the tokens
             var keyAsBytes = Encoding.UTF8.GetBytes(Configuration["Auth0:ClientSecret"]);

--- a/Samples/oidc-hs256/Support/SameSiteServiceCollectionExtensions.cs
+++ b/Samples/oidc-hs256/Support/SameSiteServiceCollectionExtensions.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace AspNetCoreOidcSample.Support
+{
+    public static class SameSiteServiceCollectionExtensions
+    {
+        public static IServiceCollection ConfigureSameSiteNoneCookies(this IServiceCollection services)
+        {
+            services.Configure<CookiePolicyOptions>(options =>
+            {
+                options.MinimumSameSitePolicy = SameSiteMode.Unspecified;
+                options.OnAppendCookie = cookieContext => CheckSameSite(cookieContext.CookieOptions);
+                options.OnDeleteCookie = cookieContext => CheckSameSite(cookieContext.CookieOptions);
+            });
+
+            return services;
+        }
+
+        private static void CheckSameSite(CookieOptions options)
+        {
+            if (options.SameSite == SameSiteMode.None && options.Secure == false)
+            {
+                options.SameSite = SameSiteMode.Unspecified;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Chrome doesn't like Cookies using SameSite=None when not running on Http.
Even tho Https is preferedm the samples and our CI are configured to run on Http.

This PR ensures the Samples work again using Http.