### PR TITLE
[SDK-1988] Update sample applications to support HTTP

### DIFF
--- a/Quickstart/00-Starter-Seed/Startup.cs
+++ b/Quickstart/00-Starter-Seed/Startup.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using SampleMvcApp.Support;
 
 namespace SampleMvcApp
 {
@@ -19,12 +20,7 @@ namespace SampleMvcApp
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.Configure<CookiePolicyOptions>(options =>
-            {
-                // This lambda determines whether user consent for non-essential cookies is needed for a given request.
-                options.CheckConsentNeeded = context => true;
-                options.MinimumSameSitePolicy = SameSiteMode.None;
-            });
+            services.ConfigureSameSiteNoneCookies();
 
             services.AddMvc()
                 .SetCompatibilityVersion(CompatibilityVersion.Version_2_1);

--- a/Quickstart/00-Starter-Seed/Support/SameSiteServiceCollectionExtensions.cs
+++ b/Quickstart/00-Starter-Seed/Support/SameSiteServiceCollectionExtensions.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SampleMvcApp.Support
+{
+    public static class SameSiteServiceCollectionExtensions
+    {
+        public static IServiceCollection ConfigureSameSiteNoneCookies(this IServiceCollection services)
+        {
+            services.Configure<CookiePolicyOptions>(options =>
+            {
+                options.MinimumSameSitePolicy = (SameSiteMode)(-1);
+                options.OnAppendCookie = cookieContext => CheckSameSite(cookieContext.CookieOptions);
+                options.OnDeleteCookie = cookieContext => CheckSameSite(cookieContext.CookieOptions);
+            });
+
+            return services;
+        }
+
+        private static void CheckSameSite(CookieOptions options)
+        {
+            if (options.SameSite == SameSiteMode.None && options.Secure == false)
+            {
+                options.SameSite = (SameSiteMode)(-1);
+            }
+        }
+    }
+}

--- a/Quickstart/01-Login/Startup.cs
+++ b/Quickstart/01-Login/Startup.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using SampleMvcApp.Support;
 using System;
 using System.Security.Claims;
 using System.Threading.Tasks;
@@ -28,12 +29,7 @@ namespace SampleMvcApp
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.Configure<CookiePolicyOptions>(options =>
-            {
-                // This lambda determines whether user consent for non-essential cookies is needed for a given request.
-                options.CheckConsentNeeded = context => HostingEnvironment.IsProduction();
-                options.MinimumSameSitePolicy = SameSiteMode.None;
-            });
+            services.ConfigureSameSiteNoneCookies();
 
             // Add authentication services
             services.AddAuthentication(options => {

--- a/Quickstart/01-Login/Support/SameSiteServiceCollectionExtensions.cs
+++ b/Quickstart/01-Login/Support/SameSiteServiceCollectionExtensions.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SampleMvcApp.Support
+{
+    public static class SameSiteServiceCollectionExtensions
+    {
+        public static IServiceCollection ConfigureSameSiteNoneCookies(this IServiceCollection services)
+        {
+            services.Configure<CookiePolicyOptions>(options =>
+            {
+                options.MinimumSameSitePolicy = (SameSiteMode)(-1);
+                options.OnAppendCookie = cookieContext => CheckSameSite(cookieContext.CookieOptions);
+                options.OnDeleteCookie = cookieContext => CheckSameSite(cookieContext.CookieOptions);
+            });
+
+            return services;
+        }
+
+        private static void CheckSameSite(CookieOptions options)
+        {
+            if (options.SameSite == SameSiteMode.None && options.Secure == false)
+            {
+                options.SameSite = (SameSiteMode) (-1);
+            }
+        }
+    }
+}

--- a/Quickstart/02-User-Profile/Startup.cs
+++ b/Quickstart/02-User-Profile/Startup.cs
@@ -12,6 +12,7 @@ using System;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.Tokens;
+using SampleMvcApp.Support;
 
 namespace SampleMvcApp
 {
@@ -29,12 +30,7 @@ namespace SampleMvcApp
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.Configure<CookiePolicyOptions>(options =>
-            {
-                // This lambda determines whether user consent for non-essential cookies is needed for a given request.
-                options.CheckConsentNeeded = context => HostingEnvironment.IsProduction();
-                options.MinimumSameSitePolicy = SameSiteMode.None;
-            });
+            services.ConfigureSameSiteNoneCookies();
 
             // Add authentication services
             services.AddAuthentication(options => {

--- a/Quickstart/02-User-Profile/Support/SameSiteServiceCollectionExtensions.cs
+++ b/Quickstart/02-User-Profile/Support/SameSiteServiceCollectionExtensions.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SampleMvcApp.Support
+{
+    public static class SameSiteServiceCollectionExtensions
+    {
+        public static IServiceCollection ConfigureSameSiteNoneCookies(this IServiceCollection services)
+        {
+            services.Configure<CookiePolicyOptions>(options =>
+            {
+                options.MinimumSameSitePolicy = (SameSiteMode)(-1);
+                options.OnAppendCookie = cookieContext => CheckSameSite(cookieContext.CookieOptions);
+                options.OnDeleteCookie = cookieContext => CheckSameSite(cookieContext.CookieOptions);
+            });
+
+            return services;
+        }
+
+        private static void CheckSameSite(CookieOptions options)
+        {
+            if (options.SameSite == SameSiteMode.None && options.Secure == false)
+            {
+                options.SameSite = (SameSiteMode) (-1);
+            }
+        }
+    }
+}

--- a/Quickstart/03-Authorization/Startup.cs
+++ b/Quickstart/03-Authorization/Startup.cs
@@ -12,6 +12,7 @@ using System;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.Tokens;
+using SampleMvcApp.Support;
 
 namespace SampleMvcApp
 {
@@ -29,12 +30,7 @@ namespace SampleMvcApp
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.Configure<CookiePolicyOptions>(options =>
-            {
-                // This lambda determines whether user consent for non-essential cookies is needed for a given request.
-                options.CheckConsentNeeded = context => HostingEnvironment.IsProduction();
-                options.MinimumSameSitePolicy = SameSiteMode.None;
-            });
+            services.ConfigureSameSiteNoneCookies();
 
             // Add authentication services
             services.AddAuthentication(options => {

--- a/Quickstart/03-Authorization/Support/SameSiteServiceCollectionExtensions.cs
+++ b/Quickstart/03-Authorization/Support/SameSiteServiceCollectionExtensions.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SampleMvcApp.Support
+{
+    public static class SameSiteServiceCollectionExtensions
+    {
+        public static IServiceCollection ConfigureSameSiteNoneCookies(this IServiceCollection services)
+        {
+            services.Configure<CookiePolicyOptions>(options =>
+            {
+                options.MinimumSameSitePolicy = (SameSiteMode)(-1);
+                options.OnAppendCookie = cookieContext => CheckSameSite(cookieContext.CookieOptions);
+                options.OnDeleteCookie = cookieContext => CheckSameSite(cookieContext.CookieOptions);
+            });
+
+            return services;
+        }
+
+        private static void CheckSameSite(CookieOptions options)
+        {
+            if (options.SameSite == SameSiteMode.None && options.Secure == false)
+            {
+                options.SameSite = (SameSiteMode) (-1);
+            }
+        }
+    }
+}

--- a/Samples/oauth2/Startup.cs
+++ b/Samples/oauth2/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using Newtonsoft.Json.Linq;
+using SampleMvcApp.Support;
 
 namespace AspNetCoreOAuth2Sample
 {
@@ -25,12 +26,7 @@ namespace AspNetCoreOAuth2Sample
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.Configure<CookiePolicyOptions>(options =>
-            {
-                // This lambda determines whether user consent for non-essential cookies is needed for a given request.
-                options.CheckConsentNeeded = context => true;
-                options.MinimumSameSitePolicy = SameSiteMode.None;
-            });
+            services.ConfigureSameSiteNoneCookies();
 
             // Add authentication services
             services.AddAuthentication(options => {

--- a/Samples/oauth2/Support/SameSiteServiceCollectionExtensions.cs
+++ b/Samples/oauth2/Support/SameSiteServiceCollectionExtensions.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SampleMvcApp.Support
+{
+    public static class SameSiteServiceCollectionExtensions
+    {
+        public static IServiceCollection ConfigureSameSiteNoneCookies(this IServiceCollection services)
+        {
+            services.Configure<CookiePolicyOptions>(options =>
+            {
+                options.MinimumSameSitePolicy = (SameSiteMode)(-1);
+                options.OnAppendCookie = cookieContext => CheckSameSite(cookieContext.CookieOptions);
+                options.OnDeleteCookie = cookieContext => CheckSameSite(cookieContext.CookieOptions);
+            });
+
+            return services;
+        }
+
+        private static void CheckSameSite(CookieOptions options)
+        {
+            if (options.SameSite == SameSiteMode.None && options.Secure == false)
+            {
+                options.SameSite = (SameSiteMode) (-1);
+            }
+        }
+    }
+}

--- a/Samples/oidc-hs256/Startup.cs
+++ b/Samples/oidc-hs256/Startup.cs
@@ -13,6 +13,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http.Authentication;
 using Microsoft.IdentityModel.Tokens;
+using SampleMvcApp.Support;
 
 namespace AspNetCoreOidcSample
 {
@@ -28,12 +29,7 @@ namespace AspNetCoreOidcSample
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.Configure<CookiePolicyOptions>(options =>
-            {
-                // This lambda determines whether user consent for non-essential cookies is needed for a given request.
-                options.CheckConsentNeeded = context => true;
-                options.MinimumSameSitePolicy = SameSiteMode.None;
-            });
+            services.ConfigureSameSiteNoneCookies();
 
             // Get the client secret used for signing the tokens
             var keyAsBytes = Encoding.UTF8.GetBytes(Configuration["Auth0:ClientSecret"]);

--- a/Samples/oidc-hs256/Support/SameSiteServiceCollectionExtensions.cs
+++ b/Samples/oidc-hs256/Support/SameSiteServiceCollectionExtensions.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SampleMvcApp.Support
+{
+    public static class SameSiteServiceCollectionExtensions
+    {
+        public static IServiceCollection ConfigureSameSiteNoneCookies(this IServiceCollection services)
+        {
+            services.Configure<CookiePolicyOptions>(options =>
+            {
+                options.MinimumSameSitePolicy = (SameSiteMode)(-1);
+                options.OnAppendCookie = cookieContext => CheckSameSite(cookieContext.CookieOptions);
+                options.OnDeleteCookie = cookieContext => CheckSameSite(cookieContext.CookieOptions);
+            });
+
+            return services;
+        }
+
+        private static void CheckSameSite(CookieOptions options)
+        {
+            if (options.SameSite == SameSiteMode.None && options.Secure == false)
+            {
+                options.SameSite = (SameSiteMode) (-1);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Update ASPNET Core 2.1 sample application to work with HTTP when using **SameSite=None** cookies