### PR TITLE
Update OIDC dependency for net5

### DIFF
--- a/Quickstart/00-Starter-Seed/appsettings.json
+++ b/Quickstart/00-Starter-Seed/appsettings.json
@@ -1,6 +1,5 @@
 ﻿{
   "Logging": {
-    "IncludeScopes": false,
     "LogLevel": {
       "Default": "Debug",
       "System": "Information",

--- a/Quickstart/01-Login/SampleMvcApp.csproj
+++ b/Quickstart/01-Login/SampleMvcApp.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.4" />
   </ItemGroup>
 </Project>

--- a/Quickstart/01-Login/appsettings.json
+++ b/Quickstart/01-Login/appsettings.json
@@ -1,6 +1,5 @@
 ﻿{
   "Logging": {
-    "IncludeScopes": false,
     "LogLevel": {
       "Default": "Debug",
       "System": "Information",

--- a/Quickstart/02-User-Profile/SampleMvcApp.csproj
+++ b/Quickstart/02-User-Profile/SampleMvcApp.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.4" />
   </ItemGroup>
 </Project>

--- a/Quickstart/02-User-Profile/appsettings.json
+++ b/Quickstart/02-User-Profile/appsettings.json
@@ -1,6 +1,5 @@
 ﻿{
   "Logging": {
-    "IncludeScopes": false,
     "LogLevel": {
       "Default": "Debug",
       "System": "Information",

--- a/Quickstart/03-Authorization/SampleMvcApp.csproj
+++ b/Quickstart/03-Authorization/SampleMvcApp.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.4" />
   </ItemGroup>
 </Project>

--- a/Quickstart/03-Authorization/appsettings.json
+++ b/Quickstart/03-Authorization/appsettings.json
@@ -1,6 +1,5 @@
 ﻿{
   "Logging": {
-    "IncludeScopes": false,
     "LogLevel": {
       "Default": "Debug",
       "System": "Information",


### PR DESCRIPTION
This PR ensures the samples use the OIDC nuget package for .net5.